### PR TITLE
Add default value to convdims

### DIFF
--- a/src/cudnn/conv.jl
+++ b/src/cudnn/conv.jl
@@ -26,7 +26,7 @@ fix1d(pdims::PoolDims{1,K,S,P,D}) where {K,S,P,D,F} =
 function cudnnConvolutionDescriptor(cdims::DenseConvDims, x::DenseCuArray{T}) where T
     cdims, x = fix1d(cdims), fix1d(x)
     mode=(NNlib.flipkernel(cdims) ? CUDNN_CROSS_CORRELATION : CUDNN_CONVOLUTION)
-    cudnnConvolutionDescriptor(convdims(nnlibPadding(cdims),size(x)), convdims(NNlib.stride(cdims),size(x)), convdims(NNlib.dilation(cdims),size(x)), mode, cudnnDataType(T), math_mode(), CUDNN_DEFAULT_REORDER, Cint(1))
+    cudnnConvolutionDescriptor(convdims(nnlibPadding(cdims),size(x),0), convdims(NNlib.stride(cdims),size(x),1), convdims(NNlib.dilation(cdims),size(x),1), mode, cudnnDataType(T), math_mode(), CUDNN_DEFAULT_REORDER, Cint(1))
 end
 
 function conv!(y::DenseCuArray{T}, x::DenseCuArray{T}, w::DenseCuArray{T}, cdims::DenseConvDims;


### PR DESCRIPTION
Github edit to add default argument to `convdims` as this is a (new) required argument in CUDA 3.1.0.

Link to commit with this change in CUDA: https://github.com/JuliaGPU/CUDA.jl/pull/873/files#