### PR TITLE
Add support for asymmetric padding for convlayers

### DIFF
--- a/src/cudnn/conv.jl
+++ b/src/cudnn/conv.jl
@@ -10,9 +10,40 @@ using CUDA.CUDNN: scalingParameter, CUDNN_CONVOLUTION, convdims,
 
 const CUDNNFloat = Union{Float16,Float32,Float64}
 
-function cudnnConvolutionDescriptor(cdims::DenseConvDims, x::DenseCuArray{T}) where T
+function cudnnConvolutionDescriptorAndPaddedInput(cdims::DenseConvDims, x::DenseCuArray{T}) where T
+    # The main purpose of this function is to catch asymmetric padding which cudnn does not support
+    # If we find asymmetric padding we'll make a copy of x which is manually padded so that we can
+    # call cudnn with symmetric padding.
+    pad = collect(NNlib.padding(cdims)) # work with an array to make things more type stable
+    all(pad[1:2:end] .== pad[2:2:end]) && return (cudnnConvolutionDescriptor(cdims, x), x, identity)
+
+    # Maybe we should warn the user that this copies data, but other ML libs generally don't warn
+    sdims = NNlib.spatial_dims(cdims)
+    
+    # Naive implementation, is there a faster way?
+    # How much we need to pad x manually: The absolute difference between pad_left and pad_right, pad_top
+    # and pad_bottom etc. respectively. We keep the sign here though because we use it below to figure out
+    # which side of x to pad.
+    pad_manual = pad[1:2:2sdims] .- pad[2:2:2sdims]
+    # How much we can let cudnn pad: The smallest padding amount between pad_left and pad_right, pad_top 
+    # and pad_bottom etc. respectively
+    pad_cudnn = min.(pad[1:2:2sdims], pad[2:2:2sdims])
+
+
+    x_padded = similar(x, (size(x)[1:sdims] .+ abs.(pad_manual))..., size(x)[end-1:end]...)
+    # We could do the same yucky indexing stuff for the zeros too so we don't have to write zeros in the whole array.
+    # Not sure if it is worth it though...
+    fill!(x_padded, 0)
+    # This is a bit yucky, but we are basically figuring out where in x_padded we shall insert x_inds
+    # Haven't benchmarked if this has any advantages over a more readable solution, e.g. writing dim by dim in a loop 
+    x_inds = range.(1 .+ max.(0, pad_manual), size(x)[1:sdims] .- min.(0, .-pad_manual))
+    x_padded[x_inds..., :, :] = x
+    return cudnnConvolutionDescriptor(cdims, x_padded, pad_cudnn), x_padded, _x -> _x[x_inds...,:,:]
+end
+
+function cudnnConvolutionDescriptor(cdims::DenseConvDims, x::DenseCuArray{T}, pad = nnlibPadding(cdims)) where T
     mode=(NNlib.flipkernel(cdims) ? CUDNN_CROSS_CORRELATION : CUDNN_CONVOLUTION)
-    cudnnConvolutionDescriptor(convdims(nnlibPadding(cdims),size(x),0),
+    cudnnConvolutionDescriptor(convdims(pad, size(x),0),
                                convdims(NNlib.stride(cdims),size(x),1),
                                convdims(NNlib.dilation(cdims),size(x),1),
                                mode,
@@ -30,7 +61,7 @@ function conv!(y::DenseCuArray{T}, x::DenseCuArray{T}, w::DenseCuArray{T}, cdims
     if algo != -1
         @warn "algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
     end
-    d = cudnnConvolutionDescriptor(cdims, x)
+    d, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
     cudnnConvolutionForward!(y, w, x, d; alpha, beta, z=y)
 end
 
@@ -43,7 +74,7 @@ function conv_bias_act!(y::DenseCuArray{T}, x::DenseCuArray{T}, w::DenseCuArray{
     if algo != -1
         @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
     end
-    d = cudnnConvolutionDescriptor(cdims, x)
+    d, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
     # only relu and identity are supported by cudnnConvolutionForward!
     activation = (σ == NNlib.relu ? CUDNN_ACTIVATION_RELU : CUDNN_ACTIVATION_IDENTITY)
     cudnnConvolutionForward!(y, w, x, d; z, bias, activation, alpha, beta)
@@ -62,13 +93,13 @@ function ∇conv_data!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, w::DenseCuArray
         @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
     end
     alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta);
+    convDesc, dx, depad = cudnnConvolutionDescriptorAndPaddedInput(cdims, dx)
     xDesc, yDesc, wDesc = cudnnTensorDescriptor(dx), cudnnTensorDescriptor(dy), cudnnFilterDescriptor(w)
-    convDesc = cudnnConvolutionDescriptor(cdims, dx)
     p = cudnnConvolutionBwdDataAlgoPerf(wDesc, w, yDesc, dy, convDesc, xDesc, dx)
     with_workspace(p.memory) do workspace
         cudnnConvolutionBackwardData(handle(), alpha, wDesc, w, yDesc, dy, convDesc, p.algo, workspace, sizeof(workspace), beta, xDesc, dx)
     end
-    return dx
+    return depad(dx) 
 end
 
 function ∇conv_filter!(dw::DenseCuArray{T}, x::DenseCuArray{T}, dy::DenseCuArray{T},
@@ -80,8 +111,8 @@ function ∇conv_filter!(dw::DenseCuArray{T}, x::DenseCuArray{T}, dy::DenseCuArr
         @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
     end
     alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta);
+    convDesc, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
     xDesc, yDesc, wDesc = cudnnTensorDescriptor(x), cudnnTensorDescriptor(dy), cudnnFilterDescriptor(dw)
-    convDesc = cudnnConvolutionDescriptor(cdims, x)
     p = cudnnConvolutionBwdFilterAlgoPerf(xDesc, x, yDesc, dy, convDesc, wDesc, dw);
     with_workspace(p.memory) do workspace
         cudnnConvolutionBackwardFilter(handle(), alpha, xDesc, x, yDesc, dy, convDesc, p.algo, workspace, sizeof(workspace), beta, wDesc, dw);

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -12,6 +12,9 @@ using NNlib: DenseConvDims
     options = Dict{Any, Any}.((
         (), (:dilation => 2), (:flipkernel => true), (:stride => 2),
         (:padding => 1),
+        (:padding => (1,0)),
+        (:padding => (0,1)),
+        (:padding => (2,3)),
     ))
     C_in_ = 3
     C_out = 4
@@ -26,6 +29,14 @@ using NNlib: DenseConvDims
 
         for opts in options
             opts[:groups] = groups
+            
+            if :padding in keys(opts)
+                padding = opts[:padding]
+                if 1 < length(padding) && length(padding) != 2num_spatial_dims
+                    opts[:padding] = ntuple(i -> padding[mod1(i,2)] .+ 2div(i-1,2), 2num_spatial_dims)   
+                end
+            end
+
             cdims = DenseConvDims(x, w; opts...)
             y = NNlib.conv(x, w, cdims)
 
@@ -44,5 +55,4 @@ using NNlib: DenseConvDims
             gputest((w, x, y) -> NNlib.∇conv_filter!(copy(w), x, y, cdims; beta=2.0), w, x, y, checkgrad=false) # TODO
         end
     end
-
 end


### PR DESCRIPTION

Closes https://github.com/JuliaGPU/CUDA.jl/issues/128 (and probably a few issues in Flux too)

This adds support for asymmetric padding which previously warned and then crashed (because NNLib sent an output array sized based on the asymmetric padding).

This is done by reducing the amount of padding sent to cudnn so it is symmetric while manually padding the input array (by creating a new array) by the removed amount. 

The function which does this is `cudnnConvolutionDescriptorAndPaddedInput` and it returns 1) a `cudnnConvolutionDescriptor` with the reduced amount of padding, 2) a (potentially) padded input array and 3) a function which undoes the manual padding (needed for gradient w.r.t input).

I haven't made much effort in optimizing `cudnnConvolutionDescriptorAndPaddedInput` and `@code_warntype` shows that the number of dimensions of the output array can't be inferred which might be bad. Suggestions on how to fix that (preferably without handling each case separately) are welcome.

I suppose that another option on the table is to resize the output array (well, make a padded copy) and increase the padding to be symmetrical and then slice out the relevant part of the output. I haven't tried implementing this as it did not fit as well into the current structure but I could give it a shot if anyone thinks its worthwhile to try.

I made some benchmarks to see that performance does not take a too large hit, but I'm not sure I have tried the most relevant cases.

With PR:
```julia
julia> cc = Conv((2,4), 1=>1; pad=SamePad())
Conv((2, 4), 1 => 1, pad=(1, 0, 2, 1))  # 9 parameters

julia> ccg = cc |> gpu
Conv((2, 4), 1 => 1, pad=(1, 0, 2, 1))  # 9 parameters

julia> xx = randn(Float32, 3,6,1,1);

julia> @benchmark CUDA.@sync($ccg(x)) setup=(x=gpu(xx))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  178.000 μs …   1.793 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     193.100 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   225.937 μs ± 152.661 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 8.02 KiB, allocs estimate: 168.
 
julia> cc = Conv((2,4), 1=>1) # No padding -> no new array created
Conv((2, 4), 1 => 1)  # 9 parameters

julia> ccg = cc |> gpu
Conv((2, 4), 1 => 1)  # 9 parameters

julia> @benchmark CUDA.@sync($ccg(x)) setup=(x=gpu(xx))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  145.600 μs …   1.426 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     167.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   188.960 μs ± 139.103 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 5.55 KiB, allocs estimate: 107.
```

Using NNLibCUDA 0.1.11:

```julia

julia> cc = Conv((2,4), 1=>1)
Conv((2, 4), 1 => 1)  # 9 parameters

julia> ccg = cc |> gpu
Conv((2, 4), 1 => 1)  # 9 parameters

julia> xx = randn(Float32, 3,6,1,1);

julia> @benchmark CUDA.@sync($ccg(x)) setup=(x=gpu(xx))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  142.900 μs …   1.437 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     160.900 μs               ┊ GC (median):    0.00%        
 Time  (mean ± σ):   193.143 μs ± 160.710 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 4.78 KiB, allocs estimate: 89.
```
