### PR TITLE
Restrict element type of activation overrides to CUDNN datatypes

### DIFF
--- a/src/cudnn/activations.jl
+++ b/src/cudnn/activations.jl
@@ -18,13 +18,13 @@ for (f, op) in [
     @eval begin
         # in-place
         function Base.materialize!(dst::DenseCuArray{<:CUDNNFloat},
-                                   bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray}})
+                                   bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray{<:CUDNNFloat}}})
             $op(bc.args[1], dst)
             return dst
         end
 
         # out of place
-        function Base.materialize(bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray}})
+        function Base.materialize(bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray{<:CUDNNFloat}}})
             ElType = Broadcast.combine_eltypes(bc.f, bc.args)
             dst = similar(bc, ElType)
             $op(bc.args[1], dst)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -7,23 +7,16 @@
 end
 
 @testset "forward diff" begin
-    f = (x) -> logσ.(x)
-    ds = Dual.(rand(5),1)
-    @test f(ds) ≈ collect(f(CuArray(ds)))
-    f = (x) -> tanh.(x)
-    ds = Dual.(rand(5),1)
-    @test f(ds) ≈ collect(f(CuArray(ds)))
-    f = (x) -> σ.(x)
-    ds = Dual.(rand(5),1)
-    @test f(ds) ≈ collect(f(CuArray(ds)))
-    f = (x) -> elu.(x)
-    ds = Dual.(rand(5),1)
-    @test f(ds) ≈ collect(f(CuArray(ds)))
-    f = (x) -> relu.(x)
-    ds = Dual.(rand(5),1)
-    @test f(ds) ≈ collect(f(CuArray(ds)))
+    for f in NNlib.ACTIVATIONS
+        if f ∉ [:rrelu]
+            @eval gputest(x -> $f.(x), Dual.(rand(5), 1))
+        end
+    end
 end
 
+# Broadcasting over complex CuArray works without NNlibCUDA, this test checks that
+# NNlibCUDA does not cause such operations to take a fast path which does not support
+# complex numbers (e.g. CUDNN)
 @testset "complex" begin
     f(x) = tanh.(x)
     cs = rand(ComplexF64, 5)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -7,9 +7,27 @@
 end
 
 @testset "forward diff" begin
-    f(x) = logσ.(x)
+    f = (x) -> logσ.(x)
     ds = Dual.(rand(5),1)
     @test f(ds) ≈ collect(f(CuArray(ds)))
+    f = (x) -> tanh.(x)
+    ds = Dual.(rand(5),1)
+    @test f(ds) ≈ collect(f(CuArray(ds)))
+    f = (x) -> σ.(x)
+    ds = Dual.(rand(5),1)
+    @test f(ds) ≈ collect(f(CuArray(ds)))
+    f = (x) -> elu.(x)
+    ds = Dual.(rand(5),1)
+    @test f(ds) ≈ collect(f(CuArray(ds)))
+    f = (x) -> relu.(x)
+    ds = Dual.(rand(5),1)
+    @test f(ds) ≈ collect(f(CuArray(ds)))
+end
+
+@testset "complex" begin
+    f = (x) -> tanh.(x)
+    cs = rand(ComplexF64, 5)
+    @test f(cs) ≈ collect(f(CuArray(cs)))
 end
 
 @testset "softplus" begin 

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -25,7 +25,7 @@ end
 end
 
 @testset "complex" begin
-    f = (x) -> tanh.(x)
+    f(x) = tanh.(x)
     cs = rand(ComplexF64, 5)
     @test f(cs) ≈ collect(f(CuArray(cs)))
 end


### PR DESCRIPTION
Fixes #47. 

I'm not managing to run the full testset locally with a rather unclear error, however, running the activations test file manually passes. Hopefully CI also passes.

Along with adding a test for tanh with complex numbers (but no others, as I'm unsure whether they will work with complex inputs), I've also expanded the ForwardDiff.Dual testset to cover the activations affected by NNlibCUDA.

I also did a little crude test on my end to check it still used the activation overrides for floats (putting a print line inside the function and running code which should hit it, removed from the PR of course).