### PR TITLE
get rid of duplicate code in upsampling code by using dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CUDA = "3.3.1"
-NNlib = "0.8.3"
+NNlib = "0.8.6"
 julia = "1.6"
 
 [extras]

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -42,6 +42,8 @@
 
 # Forward and backward pass have been tested to produce the same output
 # as pytorch with align_corners=True - it works modulo bit noise.
+# pytorch's default is align_corners=False, because otherwise the gradients depend on the
+# image size, which should be avoided -> this should be considered here as well
 
 @inline function compute_source_index(ratio::T, dst_index, align_corners) where T
     if align_corners


### PR DESCRIPTION
This gets rid of some duplicate code which was used to launch the cuda kernels for linear / bilinear / trilinear. Has to be merged together with the corresponding PR in NNlib.

Edit: the NNlib PR is https://github.com/FluxML/NNlib.jl/pull/410 