### PR TITLE
Fix versions in Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "GPU integration with julia v1"
+  - label: "GPU integration with julia v1.6"
     plugins:
       - JuliaCI/julia#v1:
           version: "1.6" 
@@ -9,10 +9,10 @@ steps:
       cuda: "*"
     timeout_in_minutes: 60
 
-  - label: "GPU integration with julia v1.7-nightly"
+  - label: "GPU integration with julia v1"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.7-nightly"
+          version: "1.8"
       - JuliaCI/julia-test#v1: ~
     agents:
       queue: "juliagpu"


### PR DESCRIPTION
1.7 nightly no longer exists and was causing errors. Also updated to 1.8 to match configuration across the org.