### PR TITLE
overload `NNlib._rng_compat_array`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlibCUDA"
 uuid = "a00861dc-f156-4864-bf3c-e6376f28a68d"
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Adapt = "3.3"
 CUDA = "3.11"
-NNlib = "0.8.14"
+NNlib = "0.8.15"
 julia = "1.6"
 
 [extras]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 NNlib._rng_from_array(::CuArray) = CUDA.default_rng()
 
-NNlib._rng_compat_array(::CUDA.RNG, ::CuArray) = nothing
-NNlib._rng_compat_array(rng::AbstractRNG, ::CuArray) = throw(ArgumentError(
-    "cannot use RNG::$(typeof(rng)) with array::CuArray"))
+NNlib._rng_compat_array(rng::CUDA.RNG, A::CuArray) = nothing
+NNlib._rng_compat_array(rng::AbstractRNG, A::CuArray) = throw(ArgumentError(
+    "cannot use rng::$(typeof(rng)) with array::CuArray, only CUDA's own RNG type works"))
 
 function divide_kernel!(xs, ys, max_idx)
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,9 @@
 NNlib._rng_from_array(::CuArray) = CUDA.default_rng()
 
+NNlib._rng_compat_array(::CUDA.RNG, ::CuArray) = nothing
+NNlib._rng_compat_array(rng::AbstractRNG, ::CuArray) = throw(ArgumentError(
+    "cannot use RNG::$(typeof(rng)) with array::CuArray"))
+
 function divide_kernel!(xs, ys, max_idx)
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 


### PR DESCRIPTION
Needs https://github.com/FluxML/NNlib.jl/pull/458, 

is for https://github.com/FluxML/Flux.jl/pull/2150
