### PR TITLE
fix: Guard against 0-sized scatter

### DIFF
--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -44,6 +44,8 @@ function scatter_kernel!(op::OP, dst, src, idx::CUDA.CuDeviceArray{<:CartesianIn
 end
 
 function NNlib.scatter!(op::OP, dst::AnyCuArray, src::AnyCuArray, idx::AnyCuArray) where OP
+    isempty(dst) && return dst
+
     dims = NNlib.scatter_dims(dst, src, idx)
     args = if dims == 0
         max_idx = length(idx)

--- a/test/scatter.jl
+++ b/test/scatter.jl
@@ -103,4 +103,9 @@ types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}]
             end
         end
     end
+
+    a = cu([1,2,3])
+    i = cu(Int[])
+    y = NNlib.scatter(+, a, i)
+    @test isempty(y)
 end


### PR DESCRIPTION
### PR Checklist

- [X] Tests are added
- [X] Documentation, if applicable

This fixes a `DivideError` when scattering by a 0-sized array